### PR TITLE
CHK-572 due date

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "wait-for-expect": "^3.0.2"
   },
   "dependencies": {
-    "@pagopa/ts-commons": "^10.5.1",
+    "@pagopa/ts-commons": "^10.9.0",
     "axios": "^0.27.2",
     "express": "^4.17.1",
     "express-xml-bodyparser": "^0.3.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,7 @@ import {
   PPT_MULTI_BENEFICIARIO
 } from "./utils/helper";
 import { logger } from "./utils/logger";
+import { DateFromString } from "@pagopa/ts-commons/lib/dates";
 
 const avvisoMultiBeneficiario = new RegExp("^.*30200.*");
 const avvisoPAIbanNotConfigured = new RegExp("^.*30201.*");
@@ -189,7 +190,8 @@ export async function newExpressApp(
       const amountNotice = "2.00";
       const verifyPaymentNoticeRes = VerifyPaymentNoticeResponse({
         amount: +amountNotice,
-        outcome: "OK"
+        outcome: "OK",
+        dueDate: pipe(DateFromString.decode("2025-07-31"), E.getOrElseW(_ => undefined))
       });
       return res
         .status(verifyPaymentNoticeRes[0])

--- a/src/fixtures/nodoRPTResponses.ts
+++ b/src/fixtures/nodoRPTResponses.ts
@@ -2,6 +2,7 @@ import { ctFaultBean_type_nfpsp } from "../generated/nodeForPsp/ctFaultBean_type
 import { stAmount_type_nfpsp } from "../generated/nodeForPsp/stAmount_type_nfpsp";
 import { faultBean_type_ppt } from "../generated/PagamentiTelematiciPspNodoservice/faultBean_type_ppt";
 import { nodoTipoDatiPagamentoPSP_type_ppt } from "../generated/PagamentiTelematiciPspNodoservice/nodoTipoDatiPagamentoPSP_type_ppt";
+import { DateFromString } from "@pagopa/ts-commons/lib/dates";
 
 type MockResponse = readonly [number, string];
 
@@ -15,6 +16,7 @@ interface IVerifyPaymentNoticeReq {
   outcome: "OK" | "KO";
   fault?: ctFaultBean_type_nfpsp;
   amount?: stAmount_type_nfpsp;
+  dueDate?: DateFromString;
 }
 
 interface IActivateIOPaymentReq {
@@ -123,6 +125,7 @@ export const VerifyPaymentNoticeResponse = (
           <amount>${params.amount}</amount>
           <options>EQ</options>
           <paymentNote>test</paymentNote>
+          <dueDate>${params.dueDate}</dueDate>
         </paymentOptionDescription>
         <paymentOptionDescription/>
       </paymentList>

--- a/yarn.lock
+++ b/yarn.lock
@@ -495,10 +495,24 @@
     write-yaml-file "^4.1.3"
     yargs "^15.0.1"
 
-"@pagopa/ts-commons@^10.3.0", "@pagopa/ts-commons@^10.5.1":
+"@pagopa/ts-commons@^10.3.0":
   version "10.5.1"
   resolved "https://registry.yarnpkg.com/@pagopa/ts-commons/-/ts-commons-10.5.1.tgz#70ac28006be8f3031132f5483a3aa69f365e06c6"
   integrity sha512-oqzwalVRp3eMUa3COhLn18MC00e6ytmbjTtON/gZePbeeqnvuX3tJJM8FsA16OIu9EnrjWMOb/s/CFG4MnPogw==
+  dependencies:
+    abort-controller "^3.0.0"
+    agentkeepalive "^4.1.4"
+    applicationinsights "^1.8.10"
+    fp-ts "^2.11.0"
+    io-ts "^2.2.16"
+    json-set-map "^1.1.2"
+    node-fetch "^2.6.0"
+    validator "^13.7.0"
+
+"@pagopa/ts-commons@^10.9.0":
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/ts-commons/-/ts-commons-10.9.0.tgz#ca50f8f9b09499667b6f3532c897453918ed7c76"
+  integrity sha512-hnWpA8Le8ylxKGGj+IALFBhOQDgLDl8vb3opKr3MHVdkcvm4GONZkotGnnSQ3Bh/tasgmPbeOa4wAHJSLTRmXQ==
   dependencies:
     abort-controller "^3.0.0"
     agentkeepalive "^4.1.4"


### PR DESCRIPTION
The goal of this PR is to add `dueDate` in `nfpsp:verifyPaymentNoticeRes`, according to https://raw.githubusercontent.com/pagopa/pagopa-api/develop/nodo/nodeForPsp.wsdl.