### PR TITLE
CHK 855 added mock method for checkPosition api

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -21,6 +21,7 @@ import { nodoAttivaRPT_element_ppt } from "../generated/PagamentiTelematiciPspNo
 import { nodoVerificaRPT_element_ppt } from "../generated/PagamentiTelematiciPspNodoservice/nodoVerificaRPT_element_ppt";
 import * as FespCdClient from "../services/pagopa_api/FespCdClient";
 import {logger} from "../utils/logger";
+import { CheckPositionResponseError, CheckPositionResponseKo, CheckPositionResponseOk } from "../fixtures/checkPosition";
 
 const sleep = (ms: number) => new Promise(ok => setTimeout(ok, ms));
 // tslint:disable-next-line: no-let
@@ -260,7 +261,7 @@ describe("Test SOAP Server", () => {
   });
 });
 
-describe("closePayment", () => {
+describe("New Node call flow", () => {
   // tslint:disable-next-line:no-identical-functions
   beforeAll(async () => {
     // Retrieve server configuration
@@ -395,4 +396,165 @@ describe("closePayment", () => {
     expect(status).toEqual(422);
     expect(responseData.outcome).toEqual("KO");
   });
+
+  it("checkPosition should return a OK response", async () => {
+    const config = pipe(
+        Configuration.decode(CONFIG),
+        E.getOrElseW(() => {
+          throw Error(`Invalid configuration.`);
+        })
+    );
+    const restClient = new RestClient({
+      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
+    });
+
+    const request = await restClient.checkPosition({
+      mocktype: undefined,
+      positionslist:[
+        {
+          fiscalCode : "68289200126",
+          noticeNumber: "0000050951923271908"
+        }
+      ]
+    });
+
+    const [status,responseData] = pipe(
+      request,
+        E.getOrElseW(l => {
+          logger.info(l);
+          throw new Error("Expected `Right` on checkPosition");
+        })
+    );
+    expect((responseData as CheckPositionResponseOk).esito).toEqual("OK")
+    expect(status).toEqual(200);
+  });
+
+  it("checkPosition should return a KO response", async () => {
+    const config = pipe(
+        Configuration.decode(CONFIG),
+        E.getOrElseW(() => {
+          throw Error(`Invalid configuration.`);
+        })
+    );
+    const restClient = new RestClient({
+      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
+    });
+
+    const request = await restClient.checkPosition({
+      mocktype: undefined,
+      positionslist:[
+        {
+          fiscalCode : "68289200126",
+          noticeNumber: "3333050951923271908"
+        }
+      ]
+    });
+
+    const [status,responseData] = pipe(
+      request,
+        E.getOrElseW(l => {
+          logger.info(l);
+          throw new Error("Expected `Right` on checkPosition");
+        })
+    );
+    expect((responseData as CheckPositionResponseKo).esito).toEqual("KO")
+    expect(status).toEqual(200);
+  });
+
+  it("checkPosition should return a 404 not found response", async () => {
+    const config = pipe(
+        Configuration.decode(CONFIG),
+        E.getOrElseW(() => {
+          throw Error(`Invalid configuration.`);
+        })
+    );
+    const restClient = new RestClient({
+      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
+    });
+
+    const request = await restClient.checkPosition({
+      mocktype: "404",
+      positionslist:[
+        {
+          fiscalCode : "68289200126",
+          noticeNumber: "0000050951923271908"
+        }
+      ]
+    });
+
+    const [status,responseData] = pipe(
+      request,
+        E.getOrElseW(l => {
+          logger.info(l);
+          throw new Error("Expected `Right` on checkPosition");
+        })
+    );
+    expect((responseData as CheckPositionResponseError).error).toEqual("404 not found")
+    expect(status).toEqual(404);
+  });
+
+  it("checkPosition should return a 408 request timeout response", async () => {
+    const config = pipe(
+        Configuration.decode(CONFIG),
+        E.getOrElseW(() => {
+          throw Error(`Invalid configuration.`);
+        })
+    );
+    const restClient = new RestClient({
+      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
+    });
+
+    const request = await restClient.checkPosition({
+      mocktype: "408",
+      positionslist:[
+        {
+          fiscalCode : "68289200126",
+          noticeNumber: "0000050951923271908"
+        }
+      ]
+    });
+
+    const [status,responseData] = pipe(
+      request,
+        E.getOrElseW(l => {
+          logger.info(l);
+          throw new Error("Expected `Right` on checkPosition");
+        })
+    );
+    expect((responseData as CheckPositionResponseError).error).toEqual("408 request timeout")
+    expect(status).toEqual(408);
+  });
+
+  it("checkPosition should return a 422 unprocessable entry response", async () => {
+    const config = pipe(
+        Configuration.decode(CONFIG),
+        E.getOrElseW(() => {
+          throw Error(`Invalid configuration.`);
+        })
+    );
+    const restClient = new RestClient({
+      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
+    });
+
+    const request = await restClient.checkPosition({
+      mocktype: "422",
+      positionslist:[
+        {
+          fiscalCode : "68289200126",
+          noticeNumber: "0000050951923271908"
+        }
+      ]
+    });
+
+    const [status,responseData] = pipe(
+      request,
+        E.getOrElseW(l => {
+          logger.info(l);
+          throw new Error("Expected `Right` on checkPosition");
+        })
+    );
+    expect((responseData as CheckPositionResponseError).error).toEqual("422 unprocessable entry")
+    expect(status).toEqual(422);
+  });
+
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import { DateFromString } from "@pagopa/ts-commons/lib/dates";
 import { formatValidationErrors } from "io-ts-reporters";
 import { CONFIG, Configuration } from "./config";
 import { closePayment, ClosePaymentRequest } from "./fixtures/closePayment";
+import { checkPosition, CheckPositionRequest } from "./fixtures/checkPosition";
 import {
   activateIOPaymenResponse,
   activatePaymenNoticeResponse,
@@ -271,6 +272,20 @@ export const newExpressApp = async (
         return res
           .status(400)
           .json({ descrizione: "closePayment: bad request", esito: "KO" });
+      })
+    )
+  );
+
+  app.post("/nodo-per-pm/v1/checkPosition", async (req, res) =>
+    pipe(
+      CheckPositionRequest.decode(req.body),
+      E.map(checkPosition),
+      E.map(([response, status]) => res.status(status).json(response)),
+      E.mapLeft(errors => {
+        logger.error(formatValidationErrors(errors));
+        return res
+          .status(400)
+          .json({ descrizione: "checkPosition: bad request", esito: "KO" });
       })
     )
   );

--- a/src/fixtures/checkPosition.ts
+++ b/src/fixtures/checkPosition.ts
@@ -18,19 +18,30 @@ const CheckPositionResponseKO = t.interface({
   esito: t.literal("KO")
 });
 
-const CheckPositionResponseError = t.interface({
+const CheckPositionResponseERROR = t.interface({
   error: t.string
 });
 
 export const CheckPositionResponse = t.union([
   CheckPositionResponseOK,
   CheckPositionResponseKO,
-  CheckPositionResponseError
+  CheckPositionResponseERROR
 ]);
+export type CheckPositionResponse = t.TypeOf<typeof CheckPositionResponse>;
 
 export const CheckPositionRequest = CheckPositionRequestMock;
 export type CheckPositionRequest = t.TypeOf<typeof CheckPositionRequest>;
-export type CheckPositionResponse = t.TypeOf<typeof CheckPositionResponse>;
+
+export const CheckPositionResponseKo = CheckPositionResponseKO;
+export type CheckPositionResponseKo = t.TypeOf<typeof CheckPositionResponseKo>;
+
+export const CheckPositionResponseOk = CheckPositionResponseOK;
+export type CheckPositionResponseOk = t.TypeOf<typeof CheckPositionResponseOk>;
+
+export const CheckPositionResponseError = CheckPositionResponseERROR;
+export type CheckPositionResponseError = t.TypeOf<
+  typeof CheckPositionResponseError
+>;
 
 export const checkPosition = (
   req: CheckPositionRequest
@@ -52,9 +63,9 @@ export const checkPosition = (
   } else if (req.mocktype === "422") {
     return [
       {
-        error: "422 Unprocessable entry"
+        error: "422 unprocessable entry"
       },
-      408
+      422
     ];
   }
 

--- a/src/fixtures/checkPosition.ts
+++ b/src/fixtures/checkPosition.ts
@@ -5,7 +5,8 @@ const SinglePosition = t.interface({
   noticeNumber: t.string
 });
 
-const CheckPositionRequestOK = t.interface({
+const CheckPositionRequestMock = t.interface({
+  mocktype: t.union([t.undefined, t.string]),
   positionslist: t.array(SinglePosition)
 });
 
@@ -18,7 +19,7 @@ const CheckPositionResponseKO = t.interface({
 });
 
 const CheckPositionResponseError = t.interface({
-  error: t.literal("generic error")
+  error: t.string
 });
 
 export const CheckPositionResponse = t.union([
@@ -27,13 +28,48 @@ export const CheckPositionResponse = t.union([
   CheckPositionResponseError
 ]);
 
-export const CheckPositionRequest = CheckPositionRequestOK;
+export const CheckPositionRequest = CheckPositionRequestMock;
 export type CheckPositionRequest = t.TypeOf<typeof CheckPositionRequest>;
 export type CheckPositionResponse = t.TypeOf<typeof CheckPositionResponse>;
 
-export const checkPosition = (): readonly [CheckPositionResponse, number] => [
-  {
-    esito: "OK"
-  },
-  200
-];
+export const checkPosition = (
+  req: CheckPositionRequest
+): readonly [CheckPositionResponse, number] => {
+  if (req.mocktype === "404") {
+    return [
+      {
+        error: "404 not found"
+      },
+      404
+    ];
+  } else if (req.mocktype === "408") {
+    return [
+      {
+        error: "408 request timeout"
+      },
+      408
+    ];
+  } else if (req.mocktype === "422") {
+    return [
+      {
+        error: "422 Unprocessable entry"
+      },
+      408
+    ];
+  }
+
+  if (req.positionslist[0].noticeNumber.startsWith("3333")) {
+    return [
+      {
+        esito: "KO"
+      },
+      200
+    ];
+  }
+  return [
+    {
+      esito: "OK"
+    },
+    200
+  ];
+};

--- a/src/fixtures/checkPosition.ts
+++ b/src/fixtures/checkPosition.ts
@@ -1,0 +1,39 @@
+import * as t from "io-ts";
+
+const SinglePosition = t.interface({
+  fiscalCode: t.string,
+  noticeNumber: t.string
+});
+
+const CheckPositionRequestOK = t.interface({
+  positionslist: t.array(SinglePosition)
+});
+
+const CheckPositionResponseOK = t.interface({
+  esito: t.literal("OK")
+});
+
+const CheckPositionResponseKO = t.interface({
+  esito: t.literal("KO")
+});
+
+const CheckPositionResponseError = t.interface({
+  error: t.literal("generic error")
+});
+
+export const CheckPositionResponse = t.union([
+  CheckPositionResponseOK,
+  CheckPositionResponseKO,
+  CheckPositionResponseError
+]);
+
+export const CheckPositionRequest = CheckPositionRequestOK;
+export type CheckPositionRequest = t.TypeOf<typeof CheckPositionRequest>;
+export type CheckPositionResponse = t.TypeOf<typeof CheckPositionResponse>;
+
+export const checkPosition = (): readonly [CheckPositionResponse, number] => [
+  {
+    esito: "OK"
+  },
+  200
+];


### PR DESCRIPTION
 The mock of the new Node checkPosition API with related integration tests has been added. 

-   to get a KO from the checkPosition mock, the mocktype field in the request json must not be valued and the 
    first noticeNumber in the input list must start with the prefix of 3333.

    ![Screenshot 2022-12-14 alle 12 59 19](https://user-images.githubusercontent.com/117268775/207589860-14de9ae3-dd82-4b31-9e04-9545ed8abc26.png)

-  to get an OK from the checkPosition mock, the mocktype field in the request json must not be valued and the 
    first noticeNumber in the input list must not start with the prefix of 3333.

   ![Screenshot 2022-12-14 alle 12 54 55](https://user-images.githubusercontent.com/117268775/207588954-d72e972e-366c-43b6-b796-fbaf811941f3.png)

- to get a 404 value the mocktype field with 404.
- to get a 408 value the mocktype field with 408.
- to get a 422 value the mocktype field with 422.

    ![Screenshot 2022-12-14 alle 13 01 05](https://user-images.githubusercontent.com/117268775/207590227-0502cf21-be97-42d0-ba85-79a4d45051ab.png)
