### PR TITLE
CHK-1308-fix-checkposition

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -438,7 +438,6 @@ describe("New Node call flow", () => {
     });
 
     const request = await restClient.checkPosition({
-      mocktype: undefined,
       positionslist:[
         {
           state : undefined,
@@ -472,7 +471,6 @@ describe("New Node call flow", () => {
     });
 
     const request = await restClient.checkPosition({
-      mocktype: undefined,
       positionslist:[
         {
           state : undefined,
@@ -494,7 +492,8 @@ describe("New Node call flow", () => {
     expect(status).toEqual(200);
   });
 
-  it("checkPosition should return a 404 not found response", async () => {
+ 
+  it("checkPosition should return a 400 http response", async () => {
     const config = pipe(
         Configuration.decode(CONFIG),
         E.getOrElseW(() => {
@@ -506,13 +505,12 @@ describe("New Node call flow", () => {
     });
 
     const request = await restClient.checkPosition({
-      mocktype: "404",
       positionslist:[
         {
           state : undefined,
           description : undefined,
           fiscalCode : "68289200126",
-          noticeNumber: "0000050951923271908"
+          noticeNumber: "3332050951923271908"
         }
       ]
     });
@@ -524,76 +522,8 @@ describe("New Node call flow", () => {
           throw new Error("Expected `Right` on checkPosition");
         })
     );
-    expect((responseData as CheckPositionResponseError).error).toEqual("404 not found")
-    expect(status).toEqual(404);
-  });
-
-  it("checkPosition should return a 408 request timeout response", async () => {
-    const config = pipe(
-        Configuration.decode(CONFIG),
-        E.getOrElseW(() => {
-          throw Error(`Invalid configuration.`);
-        })
-    );
-    const restClient = new RestClient({
-      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
-    });
-
-    const request = await restClient.checkPosition({
-      mocktype: "408",
-      positionslist:[
-        {
-          state : undefined,
-          description : undefined,
-          fiscalCode : "68289200126",
-          noticeNumber: "0000050951923271908"
-        }
-      ]
-    });
-
-    const [status,responseData] = pipe(
-      request,
-        E.getOrElseW(l => {
-          logger.info(l);
-          throw new Error("Expected `Right` on checkPosition");
-        })
-    );
-    expect((responseData as CheckPositionResponseError).error).toEqual("408 request timeout")
-    expect(status).toEqual(408);
-  });
-
-  it("checkPosition should return a 422 unprocessable entry response", async () => {
-    const config = pipe(
-        Configuration.decode(CONFIG),
-        E.getOrElseW(() => {
-          throw Error(`Invalid configuration.`);
-        })
-    );
-    const restClient = new RestClient({
-      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
-    });
-
-    const request = await restClient.checkPosition({
-      mocktype: "422",
-      positionslist:[
-        {
-          state : undefined,
-          description : undefined,
-          fiscalCode : "68289200126",
-          noticeNumber: "0000050951923271908"
-        }
-      ]
-    });
-
-    const [status,responseData] = pipe(
-      request,
-        E.getOrElseW(l => {
-          logger.info(l);
-          throw new Error("Expected `Right` on checkPosition");
-        })
-    );
-    expect((responseData as CheckPositionResponseError).error).toEqual("422 unprocessable entry")
-    expect(status).toEqual(422);
+    expect((responseData as CheckPositionResponseError).description).toEqual("Error 400")
+    expect(status).toEqual(400);
   });
 
 });

--- a/src/fixtures/checkPosition.ts
+++ b/src/fixtures/checkPosition.ts
@@ -8,7 +8,6 @@ const SinglePosition = t.interface({
 });
 
 const CheckPositionRequestMock = t.interface({
-  mocktype: t.union([t.undefined, t.string]),
   positionslist: t.array(SinglePosition)
 });
 
@@ -23,7 +22,8 @@ const CheckPositionResponseKO = t.interface({
 });
 
 const CheckPositionResponseERROR = t.interface({
-  error: t.string
+  description: t.string,
+  outcome: t.literal("KO")
 });
 
 export const CheckPositionResponse = t.union([
@@ -50,30 +50,15 @@ export type CheckPositionResponseError = t.TypeOf<
 export const checkPosition = (
   req: CheckPositionRequest
 ): readonly [CheckPositionResponse, number] => {
-  if (req.mocktype === "404") {
+  if (req.positionslist[0].noticeNumber.startsWith("3332")) {
     return [
       {
-        error: "404 not found"
+        description: "Error 400",
+        outcome: "KO"
       },
-      404
+      400
     ];
-  } else if (req.mocktype === "408") {
-    return [
-      {
-        error: "408 request timeout"
-      },
-      408
-    ];
-  } else if (req.mocktype === "422") {
-    return [
-      {
-        error: "422 unprocessable entry"
-      },
-      422
-    ];
-  }
-
-  if (req.positionslist[0].noticeNumber.startsWith("3333")) {
+  } else if (req.positionslist[0].noticeNumber.startsWith("3333")) {
     return [
       {
         outcome: "KO",


### PR DESCRIPTION
Fixed checkposition api mock.
With the new management if we pass as the first element of the positionslist an RPTID starting at 3333 the service will respond with a 400 httpresponse code and a body with outcome = KO and a description of the error.
If it starts with 3332 the service will respond with a 200 http response code and a body with KO outcome and the positionslist passed input