### PR TITLE
Node mock all ccp

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -265,7 +265,7 @@ export const newExpressApp = async (
     if (soapRequest["ns2:activatepaymentnoticev2request"]) {
       const fiscalCode =
         soapRequest["ns2:activatepaymentnoticev2request"][0].qrcode[0]
-          .fiscalcode;
+          .fiscalcode[0];
       if (fiscalCode === "77777777776") {
         logger.info("fiscalCode: ".concat(fiscalCode));
         const activatePaymenRes1 = activateV2PaymenNoticeResponseAllCCPlight();

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,8 @@ import { checkPosition, CheckPositionRequest } from "./fixtures/checkPosition";
 import {
   activateIOPaymenResponse,
   activatePaymenNoticeResponse,
+  activateV2PaymenNoticeResponse,
+  activateV2PaymenNoticeResponseAllCCP,
   activateV2PaymenNoticeResponseAllCCPlight,
   NodoAttivaRPT,
   NodoVerificaRPT,
@@ -260,7 +262,17 @@ export const newExpressApp = async (
     }
 
     if (soapRequest["ns2:activatepaymentnoticev2request"]) {
-      const activatePaymenRes = activateV2PaymenNoticeResponseAllCCPlight();
+      const fiscalCode =
+        soapRequest["ns2:activatepaymentnoticev2request"][0].$.fiscalCode;
+      logger.info("fiscalCode: ".concat(fiscalCode));
+      if (fiscalCode === "77777777776") {
+        const activatePaymenRes1 = activateV2PaymenNoticeResponseAllCCPlight();
+        return res.status(activatePaymenRes1[0]).send(activatePaymenRes1[1]);
+      } else if (fiscalCode === "77777777775") {
+        const activatePaymenRes2 = activateV2PaymenNoticeResponseAllCCP();
+        return res.status(activatePaymenRes2[0]).send(activatePaymenRes2[1]);
+      }
+      const activatePaymenRes = activateV2PaymenNoticeResponse();
       return res.status(activatePaymenRes[0]).send(activatePaymenRes[1]);
     }
     // The SOAP Request not implemented

--- a/src/app.ts
+++ b/src/app.ts
@@ -265,7 +265,8 @@ export const newExpressApp = async (
     if (soapRequest["ns2:activatepaymentnoticev2request"]) {
       logger.info(soapRequest["ns2:activatepaymentnoticev2request"]);
       const fiscalCode =
-        soapRequest["ns2:activatepaymentnoticev2request"][0].qrcode;
+        soapRequest["ns2:activatepaymentnoticev2request"][0].qrcode[0]
+          .fiscalCode;
       logger.info("fiscalCode: ".concat(fiscalCode));
       if (fiscalCode === "77777777776") {
         const activatePaymenRes1 = activateV2PaymenNoticeResponseAllCCPlight();

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,7 +13,7 @@ import { checkPosition, CheckPositionRequest } from "./fixtures/checkPosition";
 import {
   activateIOPaymenResponse,
   activatePaymenNoticeResponse,
-  activateV2PaymenNoticeResponseAllCCP,
+  activateV2PaymenNoticeResponseAllCCPlight,
   NodoAttivaRPT,
   NodoVerificaRPT,
   VerifyPaymentNoticeResponse
@@ -260,7 +260,7 @@ export const newExpressApp = async (
     }
 
     if (soapRequest["ns2:activatepaymentnoticev2request"]) {
-      const activatePaymenRes = activateV2PaymenNoticeResponseAllCCP();
+      const activatePaymenRes = activateV2PaymenNoticeResponseAllCCPlight();
       return res.status(activatePaymenRes[0]).send(activatePaymenRes[1]);
     }
     // The SOAP Request not implemented

--- a/src/app.ts
+++ b/src/app.ts
@@ -263,7 +263,7 @@ export const newExpressApp = async (
 
     if (soapRequest["ns2:activatepaymentnoticev2request"]) {
       const fiscalCode =
-        soapRequest["ns2:activatepaymentnoticev2request"][0].qrCode.fiscalCode;
+        soapRequest["ns2:activatepaymentnoticev2request"][0].qrCode;
       logger.info("fiscalCode: ".concat(fiscalCode));
       if (fiscalCode === "77777777776") {
         const activatePaymenRes1 = activateV2PaymenNoticeResponseAllCCPlight();

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,7 +13,6 @@ import { checkPosition, CheckPositionRequest } from "./fixtures/checkPosition";
 import {
   activateIOPaymenResponse,
   activatePaymenNoticeResponse,
-  activateV2PaymenNoticeResponse,
   activateV2PaymenNoticeResponseAllCCP,
   NodoAttivaRPT,
   NodoVerificaRPT,

--- a/src/app.ts
+++ b/src/app.ts
@@ -261,9 +261,11 @@ export const newExpressApp = async (
       return res.status(activatePaymenRes[0]).send(activatePaymenRes[1]);
     }
 
+    // eslint-disable-next-line sonarjs/no-duplicate-string
     if (soapRequest["ns2:activatepaymentnoticev2request"]) {
+      logger.info(soapRequest["ns2:activatepaymentnoticev2request"]);
       const fiscalCode =
-        soapRequest["ns2:activatepaymentnoticev2request"][0].qrCode;
+        soapRequest["ns2:activatepaymentnoticev2request"][0].qrcode;
       logger.info("fiscalCode: ".concat(fiscalCode));
       if (fiscalCode === "77777777776") {
         const activatePaymenRes1 = activateV2PaymenNoticeResponseAllCCPlight();

--- a/src/app.ts
+++ b/src/app.ts
@@ -263,7 +263,7 @@ export const newExpressApp = async (
 
     if (soapRequest["ns2:activatepaymentnoticev2request"]) {
       const fiscalCode =
-        soapRequest["ns2:activatepaymentnoticev2request"][0].$.qrcode
+        soapRequest["ns2:activatepaymentnoticev2request"][0].$.qrCode
           .fiscalCode;
       logger.info("fiscalCode: ".concat(fiscalCode));
       if (fiscalCode === "77777777776") {

--- a/src/app.ts
+++ b/src/app.ts
@@ -263,8 +263,7 @@ export const newExpressApp = async (
 
     if (soapRequest["ns2:activatepaymentnoticev2request"]) {
       const fiscalCode =
-        soapRequest["ns2:activatepaymentnoticev2request"][0].$.qrCode
-          .fiscalCode;
+        soapRequest["ns2:activatepaymentnoticev2request"][0].qrCode.fiscalCode;
       logger.info("fiscalCode: ".concat(fiscalCode));
       if (fiscalCode === "77777777776") {
         const activatePaymenRes1 = activateV2PaymenNoticeResponseAllCCPlight();

--- a/src/app.ts
+++ b/src/app.ts
@@ -263,7 +263,8 @@ export const newExpressApp = async (
 
     if (soapRequest["ns2:activatepaymentnoticev2request"]) {
       const fiscalCode =
-        soapRequest["ns2:activatepaymentnoticev2request"][0].$.fiscalCode;
+        soapRequest["ns2:activatepaymentnoticev2request"][0].$.qrcode
+          .fiscalCode;
       logger.info("fiscalCode: ".concat(fiscalCode));
       if (fiscalCode === "77777777776") {
         const activatePaymenRes1 = activateV2PaymenNoticeResponseAllCCPlight();

--- a/src/app.ts
+++ b/src/app.ts
@@ -266,7 +266,7 @@ export const newExpressApp = async (
       logger.info(soapRequest["ns2:activatepaymentnoticev2request"]);
       const fiscalCode =
         soapRequest["ns2:activatepaymentnoticev2request"][0].qrcode[0]
-          .fiscalCode;
+          .fiscalcode;
       logger.info("fiscalCode: ".concat(fiscalCode));
       if (fiscalCode === "77777777776") {
         const activatePaymenRes1 = activateV2PaymenNoticeResponseAllCCPlight();

--- a/src/app.ts
+++ b/src/app.ts
@@ -263,15 +263,15 @@ export const newExpressApp = async (
 
     // eslint-disable-next-line sonarjs/no-duplicate-string
     if (soapRequest["ns2:activatepaymentnoticev2request"]) {
-      logger.info(soapRequest["ns2:activatepaymentnoticev2request"]);
       const fiscalCode =
         soapRequest["ns2:activatepaymentnoticev2request"][0].qrcode[0]
           .fiscalcode;
-      logger.info("fiscalCode: ".concat(fiscalCode));
       if (fiscalCode === "77777777776") {
+        logger.info("fiscalCode: ".concat(fiscalCode));
         const activatePaymenRes1 = activateV2PaymenNoticeResponseAllCCPlight();
         return res.status(activatePaymenRes1[0]).send(activatePaymenRes1[1]);
       } else if (fiscalCode === "77777777775") {
+        logger.info("fiscalCode: ".concat(fiscalCode));
         const activatePaymenRes2 = activateV2PaymenNoticeResponseAllCCP();
         return res.status(activatePaymenRes2[0]).send(activatePaymenRes2[1]);
       }

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import {
   activateIOPaymenResponse,
   activatePaymenNoticeResponse,
   activateV2PaymenNoticeResponse,
+  activateV2PaymenNoticeResponseAllCCP,
   NodoAttivaRPT,
   NodoVerificaRPT,
   VerifyPaymentNoticeResponse
@@ -260,7 +261,7 @@ export const newExpressApp = async (
     }
 
     if (soapRequest["ns2:activatepaymentnoticev2request"]) {
-      const activatePaymenRes = activateV2PaymenNoticeResponse();
+      const activatePaymenRes = activateV2PaymenNoticeResponseAllCCP();
       return res.status(activatePaymenRes[0]).send(activatePaymenRes[1]);
     }
     // The SOAP Request not implemented

--- a/src/fixtures/nodoRPTResponses.ts
+++ b/src/fixtures/nodoRPTResponses.ts
@@ -216,7 +216,7 @@ export const activateV2PaymenNoticeResponseAllCCP = (): MockResponse => [
             <outcome>OK</outcome>
             <totalAmount>100.00</totalAmount>
             <paymentDescription>Quota Albo Ordine Giornalisti 2022</paymentDescription>
-            <fiscalCodePA>77777777777</fiscalCodePA>
+            <fiscalCodePA>77777777775</fiscalCodePA>
             <companyName>company</companyName>
             <officeName>office</officeName>
             <paymentToken>d56d327bb84047539023d98f04a63cad</paymentToken>
@@ -224,7 +224,7 @@ export const activateV2PaymenNoticeResponseAllCCP = (): MockResponse => [
                 <transfer>
                     <idTransfer>1</idTransfer>
                     <transferAmount>50.00</transferAmount>
-                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <fiscalCodePA>77777777775</fiscalCodePA>
                     <IBAN>IT45R0760103200000000001016</IBAN>
                     <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
                     <transferCategory>transferCategoryTest</transferCategory>
@@ -238,7 +238,7 @@ export const activateV2PaymenNoticeResponseAllCCP = (): MockResponse => [
                 <transfer>
                     <idTransfer>2</idTransfer>
                     <transferAmount>50.00</transferAmount>
-                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <fiscalCodePA>77777777775</fiscalCodePA>
                     <richiestaMarcaDaBollo>
                         <hashDocumento>documentHash</hashDocumento>
                         <tipoBollo>type</tipoBollo>
@@ -267,7 +267,7 @@ export const activateV2PaymenNoticeResponseAllCCPlight = (): MockResponse => [
             <outcome>OK</outcome>
             <totalAmount>100.00</totalAmount>
             <paymentDescription>Quota Albo Ordine Giornalisti 2022</paymentDescription>
-            <fiscalCodePA>77777777777</fiscalCodePA>
+            <fiscalCodePA>77777777776</fiscalCodePA>
             <companyName>company</companyName>
             <officeName>office</officeName>
             <paymentToken>d56d327bb84047539023d98f04a63cad</paymentToken>
@@ -275,7 +275,7 @@ export const activateV2PaymenNoticeResponseAllCCPlight = (): MockResponse => [
                 <transfer>
                     <idTransfer>1</idTransfer>
                     <transferAmount>50.00</transferAmount>
-                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <fiscalCodePA>77777777776</fiscalCodePA>
                     <IBAN>IT20U0760116100000000000000</IBAN>
                     <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
                     <transferCategory>transferCategoryTest</transferCategory> 
@@ -283,7 +283,7 @@ export const activateV2PaymenNoticeResponseAllCCPlight = (): MockResponse => [
                 <transfer>
                     <idTransfer>2</idTransfer>
                     <transferAmount>50.00</transferAmount>
-                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <fiscalCodePA>77777777776</fiscalCodePA>
                     <IBAN>IT20U0760116100000123000000</IBAN>
                     <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
                 </transfer>

--- a/src/fixtures/nodoRPTResponses.ts
+++ b/src/fixtures/nodoRPTResponses.ts
@@ -207,3 +207,54 @@ export const activateV2PaymenNoticeResponse = (): MockResponse => [
     </soapenv:Body>
     </soapenv:Envelope>`
 ];
+
+export const activateV2PaymenNoticeResponseAllCCP = (): MockResponse => [
+  200,
+  `<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:common="http://pagopa-api.pagopa.gov.it/xsd/common-types/v1.0.0/" xmlns:nfp="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.xsd">
+    <soapenv:Body>
+        <nfp:activatePaymentNoticeV2Response>
+            <outcome>OK</outcome>
+            <totalAmount>100.00</totalAmount>
+            <paymentDescription>Quota Albo Ordine Giornalisti 2022</paymentDescription>
+            <fiscalCodePA>77777777777</fiscalCodePA>
+            <companyName>company</companyName>
+            <officeName>office</officeName>
+            <paymentToken>d56d327bb84047539023d98f04a63cad</paymentToken>
+            <transferList>
+                <transfer>
+                    <idTransfer>1</idTransfer>
+                    <transferAmount>50.00</transferAmount>
+                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <IBAN>IT45R0760103200000000001016</IBAN>
+                    <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
+                    <transferCategory>transferCategoryTest</transferCategory>
+                    <metadata>
+                      <mapEntry>
+                        <key>IBANAPPOGGIO</key>
+                        <value>IT20U0760116100000000000000</value>
+                      </mapEntry>
+                    </metadata>   
+                </transfer>
+                <transfer>
+                    <idTransfer>2</idTransfer>
+                    <transferAmount>50.00</transferAmount>
+                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <richiestaMarcaDaBollo>
+                        <hashDocumento>documentHash</hashDocumento>
+                        <tipoBollo>type</tipoBollo>
+                        <provinciaResidenza>Foggia</provinciaResidenza>
+                    </richiestaMarcaDaBollo>
+                    <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
+                    <metadata>
+                      <mapEntry>
+                        <key>IBANAPPOGGIO</key>
+                        <value>IT20U0760116100000000000000</value>
+                      </mapEntry>
+                    </metadata>
+                </transfer>
+            </transferList>
+            <creditorReferenceId>11137215100062787</creditorReferenceId>
+        </nfp:activatePaymentNoticeV2Response>
+    </soapenv:Body>
+    </soapenv:Envelope>`
+];

--- a/src/fixtures/nodoRPTResponses.ts
+++ b/src/fixtures/nodoRPTResponses.ts
@@ -258,3 +258,38 @@ export const activateV2PaymenNoticeResponseAllCCP = (): MockResponse => [
     </soapenv:Body>
     </soapenv:Envelope>`
 ];
+
+export const activateV2PaymenNoticeResponseAllCCPlight = (): MockResponse => [
+  200,
+  `<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:common="http://pagopa-api.pagopa.gov.it/xsd/common-types/v1.0.0/" xmlns:nfp="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.xsd">
+    <soapenv:Body>
+        <nfp:activatePaymentNoticeV2Response>
+            <outcome>OK</outcome>
+            <totalAmount>100.00</totalAmount>
+            <paymentDescription>Quota Albo Ordine Giornalisti 2022</paymentDescription>
+            <fiscalCodePA>77777777777</fiscalCodePA>
+            <companyName>company</companyName>
+            <officeName>office</officeName>
+            <paymentToken>d56d327bb84047539023d98f04a63cad</paymentToken>
+            <transferList>
+                <transfer>
+                    <idTransfer>1</idTransfer>
+                    <transferAmount>50.00</transferAmount>
+                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <IBAN>IT20U0760116100000000000000</IBAN>
+                    <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
+                    <transferCategory>transferCategoryTest</transferCategory> 
+                </transfer>
+                <transfer>
+                    <idTransfer>2</idTransfer>
+                    <transferAmount>50.00</transferAmount>
+                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <IBAN>IT20U0760116100000123000000</IBAN>
+                    <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
+                </transfer>
+            </transferList>
+            <creditorReferenceId>11137215100062787</creditorReferenceId>
+        </nfp:activatePaymentNoticeV2Response>
+    </soapenv:Body>
+    </soapenv:Envelope>`
+];


### PR DESCRIPTION
Add different responses based on allCCP flag evaluation desired.

Since allCCP flag comes from transfer iban field and metadata field and depends from a kind of evaluation (light or strict) that ecommerce wants to perform, 3 different kind of responses are introduced depending on pa fiscal code

- `77777777777` response that results in allCCP flag false
- `77777777776` response that results in allCCP flag true only if light check for allCPP is enabled
- `77777777775` response that results in allCCP flag true (light and strict flag)

Note that light check for allCCP means that checkings are performed on iban field of transfer, while strict check means that checkings are performed in metadata transfer to have `"IBANAPPOGGIO"` key and one of this or iban field has to contains poste abi code 07601
