### PR TITLE
feat: add mock for activate metadata

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import {
   activateV2PaymenNoticeResponse,
   activateV2PaymenNoticeResponseAllCCP,
   activateV2PaymenNoticeResponseAllCCPlight,
+  activateV2PaymenNoticeResponseWithConventionMetadata,
   NodoAttivaRPT,
   NodoVerificaRPT,
   VerifyPaymentNoticeResponse
@@ -266,14 +267,16 @@ export const newExpressApp = async (
       const fiscalCode =
         soapRequest["ns2:activatepaymentnoticev2request"][0].qrcode[0]
           .fiscalcode[0];
+      logger.info("fiscalCode: ".concat(fiscalCode));
       if (fiscalCode === "77777777776") {
-        logger.info("fiscalCode: ".concat(fiscalCode));
         const activatePaymenRes1 = activateV2PaymenNoticeResponseAllCCPlight();
         return res.status(activatePaymenRes1[0]).send(activatePaymenRes1[1]);
       } else if (fiscalCode === "77777777775") {
-        logger.info("fiscalCode: ".concat(fiscalCode));
         const activatePaymenRes2 = activateV2PaymenNoticeResponseAllCCP();
         return res.status(activatePaymenRes2[0]).send(activatePaymenRes2[1]);
+      } else if (fiscalCode === "77777777774") {
+        const activatePaymenRes3 = activateV2PaymenNoticeResponseWithConventionMetadata();
+        return res.status(activatePaymenRes3[0]).send(activatePaymenRes3[1]);
       }
       const activatePaymenRes = activateV2PaymenNoticeResponse();
       return res.status(activatePaymenRes[0]).send(activatePaymenRes[1]);

--- a/src/fixtures/nodoRPTResponses.ts
+++ b/src/fixtures/nodoRPTResponses.ts
@@ -306,3 +306,64 @@ export const activateV2PaymenNoticeResponseAllCCPlight = (): MockResponse => [
     </soapenv:Body>
     </soapenv:Envelope>`
 ];
+
+export const activateV2PaymenNoticeResponseWithConventionMetadata = (): MockResponse => [
+  200,
+  `<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:common="http://pagopa-api.pagopa.gov.it/xsd/common-types/v1.0.0/" xmlns:nfp="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.xsd">
+    <soapenv:Body>
+        <nfp:activatePaymentNoticeV2Response>
+            <outcome>OK</outcome>
+            <totalAmount>100.00</totalAmount>
+            <paymentDescription>Quota Albo Ordine Giornalisti - ${Math.floor(
+              Math.random() * 99999999999
+            )}</paymentDescription>
+            <fiscalCodePA>77777777775</fiscalCodePA>
+            <companyName>company_${Math.floor(
+              Math.random() * 99999999999
+            )}</companyName>
+            <officeName>office</officeName>
+            <paymentToken>${randomUUID().replace(/-/g, "")}</paymentToken>
+            <transferList>
+                <transfer>
+                    <idTransfer>1</idTransfer>
+                    <transferAmount>50.00</transferAmount>
+                    <fiscalCodePA>77777777775</fiscalCodePA>
+                    <IBAN>IT45R0760103200000000001016</IBAN>
+                    <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
+                    <transferCategory>transferCategoryTest</transferCategory>
+                    <metadata>
+                      <mapEntry>
+                        <key>IBANAPPOGGIO</key>
+                        <value>IT20U0760116100000000000000</value>
+                      </mapEntry>
+                    </metadata>   
+                </transfer>
+                <transfer>
+                    <idTransfer>2</idTransfer>
+                    <transferAmount>50.00</transferAmount>
+                    <fiscalCodePA>77777777775</fiscalCodePA>
+                    <richiestaMarcaDaBollo>
+                        <hashDocumento>documentHash</hashDocumento>
+                        <tipoBollo>type</tipoBollo>
+                        <provinciaResidenza>Foggia</provinciaResidenza>
+                    </richiestaMarcaDaBollo>
+                    <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
+                    <metadata>
+                      <mapEntry>
+                        <key>IBANAPPOGGIO</key>
+                        <value>IT20U0760116100000000000000</value>
+                      </mapEntry>
+                    </metadata>
+                </transfer>
+            </transferList>
+            <creditorReferenceId>11137215100062787</creditorReferenceId>
+            <metadata>
+              <mapEntry>
+                <key>codiceConvenzione</key>
+                <value>test-codice-convenzione</value>
+              </mapEntry>
+            </metadata>   
+        </nfp:activatePaymentNoticeV2Response>
+    </soapenv:Body>
+    </soapenv:Envelope>`
+];


### PR DESCRIPTION
The goal of this PR is to add new activatePaymentV2 mock response with metadata when the fiscal code is 77777777774.