### PR TITLE
feat: add close payment ko's based on input payment token

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -281,6 +281,201 @@ describe("New Node call flow", () => {
     server.close();
   });
 
+  it("closePayment should return BAD REQUEST on appropriate payment token input", async () => {
+    const config = pipe(
+        Configuration.decode(CONFIG),
+        E.getOrElseW(() => {
+          throw Error(`Invalid configuration.`);
+        })
+    );
+    const restClient = new RestClient({
+      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
+    });
+
+    const response = await restClient.closePayment({
+      additionalPaymentInformations: {
+        mockCase: "notFound"
+      },
+      fee: 1.0,
+      idChannel: "13212880160_02",
+      idBrokerPSP: "13212880160",
+      idPSP: "CIPBITMM",
+      outcome: "OK",
+      paymentTokens: ["00000000000000000000000000000001"],
+      timestampOperation: "2022-02-22T14:41:58.811+01:00",
+      paymentMethod: "QUALSIASICOSAPAY",
+      totalAmount: 51.0,
+      transactionId: "99910087308786"
+    });
+
+    const [status, responseData] = pipe(
+        response,
+        E.getOrElseW(l => {
+          logger.info(l);
+          throw new Error("Expected `Right` on closePayment");
+        })
+    );
+
+    expect(status).toEqual(400);
+    expect(responseData.outcome).toEqual("KO");
+  });
+
+   it("closePayment should return NOT FOUND on appropriate payment token input", async () => {
+    const config = pipe(
+        Configuration.decode(CONFIG),
+        E.getOrElseW(() => {
+          throw Error(`Invalid configuration.`);
+        })
+    );
+    const restClient = new RestClient({
+      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
+    });
+
+    const response = await restClient.closePayment({
+      additionalPaymentInformations: {
+        mockCase: "notFound"
+      },
+      fee: 1.0,
+      idChannel: "13212880160_02",
+      idBrokerPSP: "13212880160",
+      idPSP: "CIPBITMM",
+      outcome: "OK",
+      paymentTokens: ["00000000000000000000000000000002"],
+      timestampOperation: "2022-02-22T14:41:58.811+01:00",
+      paymentMethod: "QUALSIASICOSAPAY",
+      totalAmount: 51.0,
+      transactionId: "99910087308786"
+    });
+
+    const [status, responseData] = pipe(
+        response,
+        E.getOrElseW(l => {
+          logger.info(l);
+          throw new Error("Expected `Right` on closePayment");
+        })
+    );
+
+    expect(status).toEqual(404);
+    expect(responseData.outcome).toEqual("KO");
+  });
+
+    it("closePayment should return UNPROCESSABLE ENTITY on appropriate payment token input", async () => {
+    const config = pipe(
+        Configuration.decode(CONFIG),
+        E.getOrElseW(() => {
+          throw Error(`Invalid configuration.`);
+        })
+    );
+    const restClient = new RestClient({
+      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
+    });
+
+    const response = await restClient.closePayment({
+      additionalPaymentInformations: {
+        mockCase: "notFound"
+      },
+      fee: 1.0,
+      idChannel: "13212880160_02",
+      idBrokerPSP: "13212880160",
+      idPSP: "CIPBITMM",
+      outcome: "OK",
+      paymentTokens: ["00000000000000000000000000000003"],
+      timestampOperation: "2022-02-22T14:41:58.811+01:00",
+      paymentMethod: "QUALSIASICOSAPAY",
+      totalAmount: 51.0,
+      transactionId: "99910087308786"
+    });
+
+    const [status, responseData] = pipe(
+        response,
+        E.getOrElseW(l => {
+          logger.info(l);
+          throw new Error("Expected `Right` on closePayment");
+        })
+    );
+
+    expect(status).toEqual(422);
+    expect(responseData.outcome).toEqual("KO");
+  });
+
+    it("closePayment should return UNPROCESSABLE ENTITY with Node did not receive RPT yet description on appropriate payment token input", async () => {
+    const config = pipe(
+        Configuration.decode(CONFIG),
+        E.getOrElseW(() => {
+          throw Error(`Invalid configuration.`);
+        })
+    );
+    const restClient = new RestClient({
+      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
+    });
+
+    const response = await restClient.closePayment({
+      additionalPaymentInformations: {
+        mockCase: "notFound"
+      },
+      fee: 1.0,
+      idChannel: "13212880160_02",
+      idBrokerPSP: "13212880160",
+      idPSP: "CIPBITMM",
+      outcome: "OK",
+      paymentTokens: ["00000000000000000000000000000004"],
+      timestampOperation: "2022-02-22T14:41:58.811+01:00",
+      paymentMethod: "QUALSIASICOSAPAY",
+      totalAmount: 51.0,
+      transactionId: "99910087308786"
+    });
+
+    const [status, responseData] = pipe(
+        response,
+        E.getOrElseW(l => {
+          logger.info(l);
+          throw new Error("Expected `Right` on closePayment");
+        })
+    );
+
+    expect(status).toEqual(422);
+    expect(responseData).toEqual({outcome: "KO", description: "Node did not receive RPT yet"});
+  });
+
+    it("closePayment should return INTERNAL SERVER ERROR on appropriate payment token input", async () => {
+    const config = pipe(
+        Configuration.decode(CONFIG),
+        E.getOrElseW(() => {
+          throw Error(`Invalid configuration.`);
+        })
+    );
+    const restClient = new RestClient({
+      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
+    });
+
+    const response = await restClient.closePayment({
+      additionalPaymentInformations: {
+        mockCase: "notFound"
+      },
+      fee: 1.0,
+      idChannel: "13212880160_02",
+      idBrokerPSP: "13212880160",
+      idPSP: "CIPBITMM",
+      outcome: "OK",
+      paymentTokens: ["00000000000000000000000000000005"],
+      timestampOperation: "2022-02-22T14:41:58.811+01:00",
+      paymentMethod: "QUALSIASICOSAPAY",
+      totalAmount: 51.0,
+      transactionId: "99910087308786"
+    });
+
+    const [status, responseData] = pipe(
+        response,
+        E.getOrElseW(l => {
+          logger.info(l);
+          throw new Error("Expected `Right` on closePayment");
+        })
+    );
+
+    expect(status).toEqual(500);
+    expect(responseData.outcome).toEqual("KO");
+  });
+
   it("closePaymentOK should return a OK response", async () => {
     const config = pipe(
         Configuration.decode(CONFIG),
@@ -464,7 +659,7 @@ describe("New Node call flow", () => {
           state : undefined,
           description : undefined,
           fiscalCode : "68289200126",
-          noticeNumber: "3332050951923271908"
+          noticeNumber: "3331050951923271908"
         }
       ]
     });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -7,7 +7,6 @@ import * as express from "express";
 import * as E from "fp-ts/lib/Either";
 import { pipe } from "fp-ts/lib/function";
 import * as http from "http";
-import {formatValidationErrors} from "io-ts-reporters";
 import waitForExpect from "wait-for-expect";
 import * as FespCdServer from "../__mock__/FespCdServer";
 import { PagamentiTelematiciPspNodoAsyncClient } from "../__mock__/PPTPortClient";
@@ -346,84 +345,6 @@ describe("New Node call flow", () => {
 
     expect(status).toEqual(200);
     expect(responseData.outcome).toEqual("OK");
-  });
-
-  it("closePayment should return NOT FOUND on appropriate mockCase", async () => {
-    const config = pipe(
-        Configuration.decode(CONFIG),
-        E.getOrElseW(() => {
-          throw Error(`Invalid configuration.`);
-        })
-    );
-    const restClient = new RestClient({
-      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
-    });
-
-    const response = await restClient.closePayment({
-      additionalPaymentInformations: {
-        mockCase: "notFound"
-      },
-      fee: 1.0,
-      idChannel: "13212880160_02",
-      idBrokerPSP: "13212880160",
-      idPSP: "CIPBITMM",
-      outcome: "OK",
-      paymentTokens: ["8b13913acff44b559ed2e6e74cd93c17"],
-      timestampOperation: "2022-02-22T14:41:58.811+01:00",
-      paymentMethod: "QUALSIASICOSAPAY",
-      totalAmount: 51.0,
-      transactionId: "99910087308786"
-    });
-
-    const [status, responseData] = pipe(
-        response,
-        E.getOrElseW(l => {
-          logger.info(l);
-          throw new Error("Expected `Right` on closePayment");
-        })
-    );
-
-    expect(status).toEqual(404);
-    expect(responseData.outcome).toEqual("KO");
-  });
-
-  it("closePayment should return UNPROCESSABLE ENTITY on appropriate mockCase", async () => {
-    const config = pipe(
-        Configuration.decode(CONFIG),
-        E.getOrElseW(() => {
-          throw Error(`Invalid configuration.`);
-        })
-    );
-    const restClient = new RestClient({
-      basepath: `http://localhost:${config.NODO_MOCK.PORT}`
-    });
-
-    const response = await restClient.closePayment({
-      additionalPaymentInformations: {
-        mockCase: "unprocessableEntity"
-      },
-      fee: 1.0,
-      idChannel: "13212880160_02",
-      idBrokerPSP: "13212880160",
-      idPSP: "CIPBITMM",
-      outcome: "OK",
-      paymentTokens: ["8b13913acff44b559ed2e6e74cd93c17"],
-      timestampOperation: "2022-02-22T14:41:58.811+01:00",
-      paymentMethod: "QUALSIASICOSAPAY",
-      totalAmount: 51.0,
-      transactionId: "99910087308786"
-    });
-
-    const [status, responseData] = pipe(
-        response,
-        E.getOrElseW(l => {
-          logger.info(formatValidationErrors(l));
-          throw new Error("Expected `Right` on closePayment");
-        })
-    );
-
-    expect(status).toEqual(422);
-    expect(responseData.outcome).toEqual("KO");
   });
 
   it("checkPosition should return a OK response", async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -291,7 +291,12 @@ export const newExpressApp = async (
     pipe(
       ClosePaymentRequest.decode(req.body),
       E.map(closePayment),
-      E.map(([response, status]) => res.status(status).json(response)),
+      E.map(async ([response, status, timeout]) => {
+        if (timeout) {
+          await new Promise(resolve => setTimeout(resolve, timeout));
+        }
+        return res.status(status).json(response);
+      }),
       E.mapLeft(errors => {
         logger.error(formatValidationErrors(errors));
         return res

--- a/src/fixtures/closePayment.ts
+++ b/src/fixtures/closePayment.ts
@@ -43,6 +43,7 @@ export const ClosePaymentResponse = t.union([
 
 export type ClosePaymentResponse = t.TypeOf<typeof ClosePaymentResponse>;
 
+const closePaymentGenericErrorDescription = "Generic error description";
 export const closePayment = (
   req: ClosePaymentRequest
   // close payment response, status code and response timeout
@@ -53,7 +54,7 @@ export const closePayment = (
       case "00000000000000000000000000000001":
         return [
           {
-            description: "Generic error description",
+            description: closePaymentGenericErrorDescription,
             outcome: "KO"
           },
           400
@@ -61,7 +62,7 @@ export const closePayment = (
       case "00000000000000000000000000000002":
         return [
           {
-            description: "Generic error description",
+            description: closePaymentGenericErrorDescription,
             outcome: "KO"
           },
           404
@@ -69,7 +70,7 @@ export const closePayment = (
       case "00000000000000000000000000000003":
         return [
           {
-            description: "Generic error description",
+            description: closePaymentGenericErrorDescription,
             outcome: "KO"
           },
           422
@@ -85,7 +86,7 @@ export const closePayment = (
       case "00000000000000000000000000000005":
         return [
           {
-            description: "Generic error description",
+            description: closePaymentGenericErrorDescription,
             outcome: "KO"
           },
           500
@@ -93,7 +94,7 @@ export const closePayment = (
       case "00000000000000000000000000000006":
         return [
           {
-            description: "Generic error description",
+            description: closePaymentGenericErrorDescription,
             outcome: "KO"
           },
           500,

--- a/src/fixtures/closePayment.ts
+++ b/src/fixtures/closePayment.ts
@@ -45,26 +45,67 @@ export type ClosePaymentResponse = t.TypeOf<typeof ClosePaymentResponse>;
 
 export const closePayment = (
   req: ClosePaymentRequest
-): readonly [ClosePaymentResponse, number] => {
+  // close payment response, status code and response timeout
+): readonly [ClosePaymentResponse, number, number?] => {
   if (req.outcome === "OK") {
-    if (req.additionalPaymentInformations.mockCase === "notFound") {
-      return [
-        {
-          description: "closePayment - mock case NOT FOUND",
-          outcome: "KO"
-        },
-        404
-      ];
-    } else if (
-      req.additionalPaymentInformations.mockCase === "unprocessableEntity"
-    ) {
-      return [
-        {
-          description: "closePayment - mock case UNPROCESSABLE ENTITY",
-          outcome: "KO"
-        },
-        422
-      ];
+    const transactionId = req.paymentTokens[0];
+    switch (transactionId) {
+      case "00000000000000000000000000000001":
+        return [
+          {
+            description: "closePayment - mock case Bad request",
+            outcome: "KO"
+          },
+          400
+        ];
+      case "00000000000000000000000000000002":
+        return [
+          {
+            description: "closePayment - mock case Not found",
+            outcome: "KO"
+          },
+          404
+        ];
+      case "00000000000000000000000000000003":
+        return [
+          {
+            description: "closePayment - mock case UNPROCESSABLE ENTITY",
+            outcome: "KO"
+          },
+          422
+        ];
+      case "00000000000000000000000000000004":
+        return [
+          {
+            description: "Node did not receive RPT yet",
+            outcome: "KO"
+          },
+          422
+        ];
+      case "00000000000000000000000000000005":
+        return [
+          {
+            description: "closePayment - mock case Generic error",
+            outcome: "KO"
+          },
+          500
+        ];
+      case "00000000000000000000000000000006":
+        return [
+          {
+            description: "closePayment - long processing response",
+            outcome: "KO"
+          },
+          500,
+          20000
+        ];
+      default:
+        return [
+          {
+            outcome: "OK"
+          },
+          200
+        ];
     }
   }
 

--- a/src/fixtures/closePayment.ts
+++ b/src/fixtures/closePayment.ts
@@ -53,7 +53,7 @@ export const closePayment = (
       case "00000000000000000000000000000001":
         return [
           {
-            description: "closePayment - mock case Bad request",
+            description: "Generic error description",
             outcome: "KO"
           },
           400
@@ -61,7 +61,7 @@ export const closePayment = (
       case "00000000000000000000000000000002":
         return [
           {
-            description: "closePayment - mock case Not found",
+            description: "Generic error description",
             outcome: "KO"
           },
           404
@@ -69,7 +69,7 @@ export const closePayment = (
       case "00000000000000000000000000000003":
         return [
           {
-            description: "closePayment - mock case UNPROCESSABLE ENTITY",
+            description: "Generic error description",
             outcome: "KO"
           },
           422
@@ -85,7 +85,7 @@ export const closePayment = (
       case "00000000000000000000000000000005":
         return [
           {
-            description: "closePayment - mock case Generic error",
+            description: "Generic error description",
             outcome: "KO"
           },
           500
@@ -93,7 +93,7 @@ export const closePayment = (
       case "00000000000000000000000000000006":
         return [
           {
-            description: "closePayment - long processing response",
+            description: "Generic error description",
             outcome: "KO"
           },
           500,


### PR DESCRIPTION
Add close payment mocked error responses based on input payment token.
Those responses will be used to test error cases such as 4xx, 5xx, timeouts and specific error response with specific description