### PR TITLE
feat: add mocks to perform close payment error flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,4 @@ Close payment have custom mocks based on payment token used to test different er
 | 00000000000000000000000000000004 | 422             | Node did not receive RPT yet  | 0                                    |
 | 00000000000000000000000000000005 | 500             | Generic error description     | 0                                    |
 | 00000000000000000000000000000006 | 500             | Generic error description     | 20 seconds *(used for timeout tests) |
+| any other value.                 | 200             | outcome KO                    | 0                                    |

--- a/README.md
+++ b/README.md
@@ -83,3 +83,35 @@ and if node mock is running you'll see the following responses :
 </s:Envelope>
 
 ```
+
+## Response Custom mocks
+
+### Activate payment response v2
+
+Activate payment response v2 have custom responses based on input payment notice fiscal code
+
+| fiscal code     | response                                                                           | note                                                                                         |
+|-----------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------| 
+| 77777777776     | OK response with all CCP response without `IBANAPPOGGIO` metadata entry            | used to test all CCP calculation algorithm                                                   | 
+| 77777777775     | OK response with all CCP response with `IBANAPPOGGIO` metadata entry               | used to test all CCP calcultion algorith                                                     |
+| 77777777774     | OK response with convention metadata informations                                  | used to mock a Node response with convention metadata                                        |
+| 66666666600     | OK response with payment token with fixed value `00000000000000000000000000000001` | used to mock a payment flow with an error on close payment (see close payment section below) |
+| 66666666601     | OK response with payment token with fixed value `00000000000000000000000000000002` | used to mock a payment flow with an error on close payment (see close payment section below) |
+| 66666666602     | OK response with payment token with fixed value `00000000000000000000000000000003` | used to mock a payment flow with an error on close payment (see close payment section below) |
+| 66666666603     | OK response with payment token with fixed value `00000000000000000000000000000004` | used to mock a payment flow with an error on close payment (see close payment section below) |
+| 66666666604     | OK response with payment token with fixed value `00000000000000000000000000000005` | used to mock a payment flow with an error on close payment (see close payment section below) |
+| 66666666605     | OK response with payment token with fixed value `00000000000000000000000000000006` | used to mock a payment flow with an error on close payment (see close payment section below) |
+| any other value | OK response                                                                        | used to test an ok payment flow                                                              |
+
+### Close payment
+
+Close payment have custom mocks based on payment token used to test different errors scenario
+
+| payment token value              | http error code | http error description        | response timeout                     |
+|----------------------------------|-----------------|-------------------------------|--------------------------------------|
+| 00000000000000000000000000000001 | 400             | Generic error description     | 0                                    |
+| 00000000000000000000000000000002 | 404             | Generic error description     | 0                                    |
+| 00000000000000000000000000000003 | 422             | Generic error description     | 0                                    |
+| 00000000000000000000000000000004 | 422             | Node did not receive RPT yet  | 0                                    |
+| 00000000000000000000000000000005 | 500             | Generic error description     | 0                                    |
+| 00000000000000000000000000000006 | 500             | Generic error description     | 20 seconds *(used for timeout tests) |

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,8 @@ import {
   activateV2PaymenNoticeResponseAllCCP,
   activateV2PaymenNoticeResponseAllCCPlight,
   activateV2PaymenNoticeResponseWithConventionMetadata,
+  activateV2PaymenNoticeResponseWithFixedPaymentToken,
+  MockResponse,
   NodoAttivaRPT,
   NodoVerificaRPT,
   VerifyPaymentNoticeResponse
@@ -268,16 +270,50 @@ export const newExpressApp = async (
         soapRequest["ns2:activatepaymentnoticev2request"][0].qrcode[0]
           .fiscalcode[0];
       logger.info("fiscalCode: ".concat(fiscalCode));
-      if (fiscalCode === "77777777776") {
-        const activatePaymenRes1 = activateV2PaymenNoticeResponseAllCCPlight();
-        return res.status(activatePaymenRes1[0]).send(activatePaymenRes1[1]);
-      } else if (fiscalCode === "77777777775") {
-        const activatePaymenRes2 = activateV2PaymenNoticeResponseAllCCP();
-        return res.status(activatePaymenRes2[0]).send(activatePaymenRes2[1]);
-      } else if (fiscalCode === "77777777774") {
-        const activatePaymenRes3 = activateV2PaymenNoticeResponseWithConventionMetadata();
-        logger.info(activatePaymenRes3);
-        return res.status(activatePaymenRes3[0]).send(activatePaymenRes3[1]);
+      const fiscalCodeToMockResponseMapping = new Map<string, MockResponse>([
+        ["77777777776", activateV2PaymenNoticeResponseAllCCPlight()],
+        ["77777777775", activateV2PaymenNoticeResponseAllCCP()],
+        ["77777777774", activateV2PaymenNoticeResponseWithConventionMetadata()],
+        [
+          "66666666600",
+          activateV2PaymenNoticeResponseWithFixedPaymentToken(
+            "00000000000000000000000000000001"
+          )
+        ],
+        [
+          "66666666601",
+          activateV2PaymenNoticeResponseWithFixedPaymentToken(
+            "00000000000000000000000000000002"
+          )
+        ],
+        [
+          "66666666602",
+          activateV2PaymenNoticeResponseWithFixedPaymentToken(
+            "00000000000000000000000000000003"
+          )
+        ],
+        [
+          "66666666603",
+          activateV2PaymenNoticeResponseWithFixedPaymentToken(
+            "00000000000000000000000000000004"
+          )
+        ],
+        [
+          "66666666604",
+          activateV2PaymenNoticeResponseWithFixedPaymentToken(
+            "00000000000000000000000000000005"
+          )
+        ],
+        [
+          "66666666605",
+          activateV2PaymenNoticeResponseWithFixedPaymentToken(
+            "00000000000000000000000000000006"
+          )
+        ]
+      ]);
+      const mockedResponse = fiscalCodeToMockResponseMapping.get(fiscalCode);
+      if (mockedResponse) {
+        return res.status(mockedResponse[0]).send(mockedResponse[1]);
       }
       const activatePaymenRes = activateV2PaymenNoticeResponse();
       return res.status(activatePaymenRes[0]).send(activatePaymenRes[1]);

--- a/src/fixtures/nodoRPTResponses.ts
+++ b/src/fixtures/nodoRPTResponses.ts
@@ -5,7 +5,7 @@ import { stAmount_type_nfpsp } from "../generated/nodeForPsp/stAmount_type_nfpsp
 import { faultBean_type_ppt } from "../generated/PagamentiTelematiciPspNodoservice/faultBean_type_ppt";
 import { nodoTipoDatiPagamentoPSP_type_ppt } from "../generated/PagamentiTelematiciPspNodoservice/nodoTipoDatiPagamentoPSP_type_ppt";
 
-type MockResponse = readonly [number, string];
+export type MockResponse = readonly [number, string];
 
 interface INodoRPTRequest {
   readonly esito: "OK" | "KO";
@@ -363,6 +363,51 @@ export const activateV2PaymenNoticeResponseWithConventionMetadata = (): MockResp
                 <value>test-codice-convenzione</value>
               </mapEntry>
             </metadata>   
+        </nfp:activatePaymentNoticeV2Response>
+    </soapenv:Body>
+    </soapenv:Envelope>`
+];
+
+export const activateV2PaymenNoticeResponseWithFixedPaymentToken = (
+  paymentToken: string
+): MockResponse => [
+  200,
+  `<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:common="http://pagopa-api.pagopa.gov.it/xsd/common-types/v1.0.0/" xmlns:nfp="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.xsd">
+    <soapenv:Body>
+        <nfp:activatePaymentNoticeV2Response>
+            <outcome>OK</outcome>
+            <totalAmount>100.00</totalAmount>
+            <paymentDescription>Quota Albo Ordine Giornalisti - ${Math.floor(
+              Math.random() * 99999999999
+            )}</paymentDescription>
+            <fiscalCodePA>77777777777</fiscalCodePA>
+            <companyName>company_${Math.floor(
+              Math.random() * 99999999999
+            )}</companyName>
+            <officeName>office</officeName>
+            <paymentToken>${paymentToken}</paymentToken>
+            <transferList>
+                <transfer>
+                    <idTransfer>1</idTransfer>
+                    <transferAmount>50.00</transferAmount>
+                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <IBAN>IT45R0760103200000000001016</IBAN>
+                    <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
+                    <transferCategory>transferCategoryTest</transferCategory>
+                </transfer>
+                <transfer>
+                    <idTransfer>2</idTransfer>
+                    <transferAmount>50.00</transferAmount>
+                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <richiestaMarcaDaBollo>
+                        <hashDocumento>documentHash</hashDocumento>
+                        <tipoBollo>type</tipoBollo>
+                        <provinciaResidenza>Foggia</provinciaResidenza>
+                    </richiestaMarcaDaBollo>
+                    <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
+                </transfer>
+            </transferList>
+            <creditorReferenceId>11137215100062787</creditorReferenceId>
         </nfp:activatePaymentNoticeV2Response>
     </soapenv:Body>
     </soapenv:Envelope>`


### PR DESCRIPTION
- Add mock logic to return specific payment tokens in  activate payment response v2  -> response payment token is set to one to simulate error on later close payment requests (already implemented), allowing to perform a complete payment flow with an ok on activate and a specific error on close payments.
- add readme documentations of close payment and activate methods
- refactor activate mock logic to use map in place of if-else change to make code clearer 