### PR TITLE
feat: [PIDM-1217] add fixed token no digital stamp case for closure tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ if all rights you'll see something like that :
 ## Environment
 
 | name                 | description                   | default            |
-| -------------------- | ----------------------------- | ------------------ |
+|----------------------|-------------------------------|--------------------|
 | WINSTON_LOG_LEVEL    | desired log level             | "debug"            |
 | PAGOPA_NODO_HOST     | host this server listens to   | "http://localhost" |
 | PORT                 | host this server listens to   | 3000               |
@@ -95,13 +95,14 @@ Activate payment response v2 have custom responses based on input payment notice
 | 77777777776     | OK response with all CCP response without `IBANAPPOGGIO` metadata entry            | used to test all CCP calculation algorithm                                                   | 
 | 77777777775     | OK response with all CCP response with `IBANAPPOGGIO` metadata entry               | used to test all CCP calcultion algorith                                                     |
 | 77777777774     | OK response with convention metadata informations                                  | used to mock a Node response with convention metadata                                        |
+| 77777777778     | OK response with a digital stamp (`richiestaMarcaDaBollo`) on the second transfer  | used to mock a digital stamp (marca da bollo) payment flow                                   |
 | 66666666600     | OK response with payment token with fixed value `00000000000000000000000000000001` | used to mock a payment flow with an error on close payment (see close payment section below) |
 | 66666666601     | OK response with payment token with fixed value `00000000000000000000000000000002` | used to mock a payment flow with an error on close payment (see close payment section below) |
 | 66666666602     | OK response with payment token with fixed value `00000000000000000000000000000003` | used to mock a payment flow with an error on close payment (see close payment section below) |
 | 66666666603     | OK response with payment token with fixed value `00000000000000000000000000000004` | used to mock a payment flow with an error on close payment (see close payment section below) |
 | 66666666604     | OK response with payment token with fixed value `00000000000000000000000000000005` | used to mock a payment flow with an error on close payment (see close payment section below) |
 | 66666666605     | OK response with payment token with fixed value `00000000000000000000000000000006` | used to mock a payment flow with an error on close payment (see close payment section below) |
-| any other value | OK response                                                                        | used to test an ok payment flow                                                              |
+| any other value | OK response with IBAN transfers only (no digital stamp)                            | used to test an ok payment flow                                                              |
 
 ### Close payment
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ import {
   activateV2PaymenNoticeResponseAllCCPlight,
   activateV2PaymenNoticeResponseWithConventionMetadata,
   activateV2PaymenNoticeResponseWithFixedPaymentToken,
+  activateV2PaymenNoticeResponseWithFixedPaymentTokenNoDigitalStamp,
   MockResponse,
   NodoAttivaRPT,
   NodoVerificaRPT,
@@ -288,7 +289,7 @@ export const newExpressApp = async (
         ],
         [
           "66666666602",
-          activateV2PaymenNoticeResponseWithFixedPaymentToken(
+          activateV2PaymenNoticeResponseWithFixedPaymentTokenNoDigitalStamp(
             "00000000000000000000000000000003"
           )
         ],

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,7 +13,8 @@ import { checkPosition, CheckPositionRequest } from "./fixtures/checkPosition";
 import {
   activateIOPaymenResponse,
   activatePaymenNoticeResponse,
-  activateV2PaymenNoticeResponse,
+  activateV2PaymentNoticeResponse,
+  activateV2PaymentNoticeResponseWithDigitalStamp,
   activateV2PaymenNoticeResponseAllCCP,
   activateV2PaymenNoticeResponseAllCCPlight,
   activateV2PaymenNoticeResponseWithConventionMetadata,
@@ -272,6 +273,7 @@ export const newExpressApp = async (
           .fiscalcode[0];
       logger.info("fiscalCode: ".concat(fiscalCode));
       const fiscalCodeToMockResponseMapping = new Map<string, MockResponse>([
+        ["77777777778", activateV2PaymentNoticeResponseWithDigitalStamp()],
         ["77777777776", activateV2PaymenNoticeResponseAllCCPlight()],
         ["77777777775", activateV2PaymenNoticeResponseAllCCP()],
         ["77777777774", activateV2PaymenNoticeResponseWithConventionMetadata()],
@@ -316,8 +318,8 @@ export const newExpressApp = async (
       if (mockedResponse) {
         return res.status(mockedResponse[0]).send(mockedResponse[1]);
       }
-      const activatePaymenRes = activateV2PaymenNoticeResponse();
-      return res.status(activatePaymenRes[0]).send(activatePaymenRes[1]);
+      const activatePaymentRes = activateV2PaymentNoticeResponse();
+      return res.status(activatePaymentRes[0]).send(activatePaymentRes[1]);
     }
     // The SOAP Request not implemented
     res.status(404).send("Not found");

--- a/src/fixtures/nodoRPTResponses.ts
+++ b/src/fixtures/nodoRPTResponses.ts
@@ -412,3 +412,45 @@ export const activateV2PaymenNoticeResponseWithFixedPaymentToken = (
     </soapenv:Body>
     </soapenv:Envelope>`
 ];
+
+export const activateV2PaymenNoticeResponseWithFixedPaymentTokenNoDigitalStamp = (
+  paymentToken: string
+): MockResponse => [
+  200,
+  `<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:common="http://pagopa-api.pagopa.gov.it/xsd/common-types/v1.0.0/" xmlns:nfp="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.xsd">
+    <soapenv:Body>
+        <nfp:activatePaymentNoticeV2Response>
+            <outcome>OK</outcome>
+            <totalAmount>100.00</totalAmount>
+            <paymentDescription>Quota Albo Ordine Giornalisti - ${Math.floor(
+              Math.random() * 99999999999
+            )}</paymentDescription>
+            <fiscalCodePA>77777777777</fiscalCodePA>
+            <companyName>company_${Math.floor(
+              Math.random() * 99999999999
+            )}</companyName>
+            <officeName>office</officeName>
+            <paymentToken>${paymentToken}</paymentToken>
+            <transferList>
+                <transfer>
+                    <idTransfer>1</idTransfer>
+                    <transferAmount>50.00</transferAmount>
+                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <IBAN>IT45R0760103200000000001016</IBAN>
+                    <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
+                    <transferCategory>transferCategoryTest</transferCategory>
+                </transfer>
+                <transfer>
+                    <idTransfer>2</idTransfer>
+                    <transferAmount>50.00</transferAmount>
+                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <IBAN>IT45R0760103200000000001016</IBAN>
+                    <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
+                    <transferCategory>transferCategoryTest</transferCategory>
+                </transfer>
+            </transferList>
+            <creditorReferenceId>11137215100062787</creditorReferenceId>
+        </nfp:activatePaymentNoticeV2Response>
+    </soapenv:Body>
+    </soapenv:Envelope>`
+];

--- a/src/fixtures/nodoRPTResponses.ts
+++ b/src/fixtures/nodoRPTResponses.ts
@@ -170,7 +170,46 @@ export const activatePaymenNoticeResponse = (): MockResponse => [
  `
 ];
 
-export const activateV2PaymenNoticeResponse = (): MockResponse => [
+export const activateV2PaymentNoticeResponse = (): MockResponse => [
+  200,
+  `<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:common="http://pagopa-api.pagopa.gov.it/xsd/common-types/v1.0.0/" xmlns:nfp="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.xsd">
+    <soapenv:Body>
+        <nfp:activatePaymentNoticeV2Response>
+            <outcome>OK</outcome>
+            <totalAmount>100.00</totalAmount>
+            <paymentDescription>Quota Albo Ordine Giornalisti - ${Math.floor(
+              Math.random() * 99999999999
+            )}</paymentDescription>
+            <fiscalCodePA>77777777777</fiscalCodePA>
+            <companyName>company_${Math.floor(
+              Math.random() * 99999999999
+            )}</companyName>
+            <officeName>office</officeName>
+            <paymentToken>${randomUUID().replace(/-/g, "")}</paymentToken>
+            <transferList>
+                <transfer>
+                    <idTransfer>1</idTransfer>
+                    <transferAmount>50.00</transferAmount>
+                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <IBAN>IT45R0760103200000000001016</IBAN>
+                    <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
+                    <transferCategory>transferCategoryTest</transferCategory>
+                </transfer>
+                <transfer>
+                    <idTransfer>2</idTransfer>
+                    <transferAmount>50.00</transferAmount>
+                    <fiscalCodePA>77777777777</fiscalCodePA>
+                    <IBAN>IT45R0760103200000000001016</IBAN>
+                    <remittanceInformation>/RFB/00202200000217527/5.00/TXT/</remittanceInformation>
+                </transfer>
+            </transferList>
+            <creditorReferenceId>11137215100062787</creditorReferenceId>
+        </nfp:activatePaymentNoticeV2Response>
+    </soapenv:Body>
+    </soapenv:Envelope>`
+];
+
+export const activateV2PaymentNoticeResponseWithDigitalStamp = (): MockResponse => [
   200,
   `<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:common="http://pagopa-api.pagopa.gov.it/xsd/common-types/v1.0.0/" xmlns:nfp="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.xsd">
     <soapenv:Body>


### PR DESCRIPTION
- add `activateV2PaymenNoticeResponseWithFixedPaymentTokenNoDigitalStamp` response function as override: same as `activateV2PaymenNoticeResponseWithFixedPaymentToken`  but with IBAN transfers instead of `richiestaMarcaDaBollo`
- remap fiscal code `66666666602` to use the new no-digital-stamp response, so closure error recovery tests work with the new digital stamp check on `pagopa-ecommerce-transactions-service` (ref. PR -> https://github.com/pagopa/pagopa-ecommerce-transactions-service/pull/727)

TEST
- transactions-service pipeline runs successfully with updated ecommerce-local tests -> [Pipeline](https://dev.azure.com/pagopaspa/pagoPA-projects/_build/results?buildId=269767&view=logs&j=5a5405a0-8439-550a-2a82-0e4c8988d6a1&t=eec4819c-8316-5751-789f-643dbbc4d13d)
